### PR TITLE
Make sure QueuedTracking plugin mimics new BulkTracking behavior and ignores unexpected website errors.

### DIFF
--- a/Queue/Processor.php
+++ b/Queue/Processor.php
@@ -61,9 +61,9 @@ class Processor
         $this->numMaxBatchesToProcess = (int) $numBatches;
     }
 
-    public function process()
+    public function process(Tracker $tracker = null)
     {
-        $tracker = new Tracker();
+        $tracker = $tracker ?: new Tracker();
 
         if (!$tracker->shouldRecordStatistics()) {
             return $tracker;

--- a/Queue/Processor/Handler.php
+++ b/Queue/Processor/Handler.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\QueuedTracking\Queue\Processor;
 
+use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Tracker;
 use Piwik\Plugins\QueuedTracking\Queue;
 use Piwik\Plugins\QueuedTracking\Queue\Backend;
@@ -41,8 +42,12 @@ class Handler
         $this->count = 0;
 
         foreach ($requestSet->getRequests() as $request) {
-            $tracker->trackRequest($request);
-            $this->count++;
+            try {
+                $tracker->trackRequest($request);
+                $this->count++;
+            } catch (UnexpectedWebsiteFoundException $ex) {
+                // empty
+            }
         }
 
         $this->requestSetsToRetry[] = $requestSet;

--- a/tests/Framework/Mock/ForcedException.php
+++ b/tests/Framework/Mock/ForcedException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\QueuedTracking\tests\Framework\Mock;
+
+class ForcedException extends \Exception
+{
+}

--- a/tests/Framework/Mock/Tracker.php
+++ b/tests/Framework/Mock/Tracker.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\QueuedTracking\tests\Framework\Mock;
+
+use Piwik\Tracker\Request;
+
+class Tracker extends \Piwik\Tests\Framework\Mock\Tracker
+{
+    public function trackRequest(Request $request)
+    {
+        $allParams = $request->getRawParams();
+        if (!empty($allParams['forceThrow'])) {
+            throw new ForcedException("forced exception");
+        }
+
+        return parent::trackRequest($request);
+    }
+}

--- a/tests/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/Framework/TestCase/IntegrationTestCase.php
@@ -69,13 +69,17 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
         $this->assertEquals($eState, $aState);
     }
 
-    protected function buildRequestSetContainingError($numberOfRequestSets, $indexThatShouldContainError)
+    protected function buildRequestSetContainingError($numberOfRequestSets, $indexThatShouldContainError, $useInvalidSiteError = false)
     {
         $requests = array();
 
         for ($i = 0; $i < $numberOfRequestSets; $i++) {
             if ($i === $indexThatShouldContainError) {
-                $requests[] = new Request(array('idsite' => '0', 'index' => $i));
+                if ($useInvalidSiteError) {
+                    $requests[] = new Request(array('idsite' => '0', 'index' => $i));
+                } else {
+                    $requests[] = new Request(array('idsite' => '1', 'index' => $i, 'forceThrow' => 1));
+                }
             } else {
                 $requests[] = new Request(array('idsite' => '1', 'index' => $i));
             }

--- a/tests/Integration/Queue/Processor/HandlerTest.php
+++ b/tests/Integration/Queue/Processor/HandlerTest.php
@@ -7,10 +7,12 @@
  */
 
 namespace Piwik\Plugins\QueuedTracking\tests\Integration\Queue\Processor;
+
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Plugins\QueuedTracking\Queue\Processor\Handler;
+use Piwik\Plugins\QueuedTracking\tests\Framework\Mock\ForcedException;
+use Piwik\Plugins\QueuedTracking\tests\Framework\Mock\Tracker;
 use Piwik\Plugins\QueuedTracking\tests\Framework\TestCase\IntegrationTestCase;
-use Piwik\Tests\Framework\Mock\Tracker;
 use Piwik\Tests\Framework\Mock\Tracker\RequestSet;
 
 class TestHandler extends Handler {
@@ -123,10 +125,17 @@ class HandlerTest extends IntegrationTestCase
         try {
             $this->handler->process($this->tracker, $this->buildRequestSetContainingError(7, 4));
             $this->fail('An expected exception was not triggered');
-        } catch (UnexpectedWebsiteFoundException $e) {
+        } catch (ForcedException $e) {
         }
 
         $this->assertSame(4, $this->tracker->getCountOfLoggedRequests());
+    }
+
+    public function test_process_ShouldIgnoreInvalidIdSiteRequests_LikeBulkTrackingPlugin()
+    {
+        $this->handler->process($this->tracker, $this->buildRequestSetContainingError(7, 4, $invalidSiteException = true));
+
+        $this->assertSame(6, $this->tracker->getCountOfLoggedRequests());
     }
 
     public function test_onException_shouldRemoveAllInvalidRequestsFromValidRequests()
@@ -136,7 +145,7 @@ class HandlerTest extends IntegrationTestCase
         try {
             $this->handler->process($this->tracker, $requestSet);
             $this->fail('An expected exception was not triggered');
-        } catch (UnexpectedWebsiteFoundException $e) {
+        } catch (ForcedException $e) {
             $this->handler->onException($requestSet, $e);
         }
 
@@ -167,7 +176,7 @@ class HandlerTest extends IntegrationTestCase
         try {
             $this->handler->process($this->tracker, $requestSet4);
             $this->fail('An expected exception was not triggered');
-        } catch (UnexpectedWebsiteFoundException $e) {
+        } catch (ForcedException $e) {
             $this->handler->onException($requestSet4, $e);
         }
 
@@ -211,7 +220,7 @@ class HandlerTest extends IntegrationTestCase
         try {
             $this->handler->process($this->tracker, $requestSet2);
             $this->fail('An expected exception was not triggered');
-        } catch (UnexpectedWebsiteFoundException $e) {
+        } catch (ForcedException $e) {
             $this->handler->onException($requestSet2, $e);
         }
 
@@ -230,7 +239,7 @@ class HandlerTest extends IntegrationTestCase
         try {
             $this->handler->process($this->tracker, $requestSet);
             $this->fail('An expected exception was not triggered');
-        } catch (UnexpectedWebsiteFoundException $e) {
+        } catch (ForcedException $e) {
             $this->handler->onException($requestSet, $e);
         }
 

--- a/tests/Integration/Queue/ProcessorTest.php
+++ b/tests/Integration/Queue/ProcessorTest.php
@@ -76,7 +76,7 @@ class ProcessorTest extends IntegrationTestCase
 
     public function test_process_shouldDoNothing_IfQueueIsEmpty()
     {
-        $tracker = $this->processor->process($this->queue);
+        $tracker = $this->processor->process();
 
         $this->assertSame(0, $tracker->getCountOfLoggedRequests());
         $this->assertNumberOfRequestSetsLeftInQueue(0);
@@ -86,7 +86,7 @@ class ProcessorTest extends IntegrationTestCase
     {
         $this->addRequestSetsToQueue(2);
 
-        $tracker = $this->processor->process($this->queue);
+        $tracker = $this->processor->process();
 
         $this->assertSame(0, $tracker->getCountOfLoggedRequests());
         $this->assertNumberOfRequestSetsLeftInQueue(2);
@@ -253,7 +253,7 @@ class ProcessorTest extends IntegrationTestCase
 
         $this->assertNumberOfRequestSetsLeftInQueue(10);
 
-        $tracker = $this->processor->process($this->queue);
+        $tracker = $this->processor->process($this->createTracker());
 
         $this->assertSame(1+5+1+2+1+4, $tracker->getCountOfLoggedRequests());
         $this->assertNumberOfRequestSetsLeftInQueue(0);
@@ -321,7 +321,7 @@ class ProcessorTest extends IntegrationTestCase
              ->with($this->anything(), $this->equalTo(array()))
              ->will($this->returnCallback($forwardCallToProcessor));
 
-        $mock->process($this->queue);
+        $mock->process($this->createTracker());
     }
 
     public function test_process_shouldRestoreEnvironmentAfterTrackingRequests()
@@ -349,7 +349,7 @@ class ProcessorTest extends IntegrationTestCase
 
     private function process()
     {
-        return $this->processor->process($this->queue);
+        return $this->processor->process();
     }
 
     private function assertNumberOfRequestSetsLeftInQueue($numRequestsLeftInQueue)
@@ -371,7 +371,7 @@ class ProcessorTest extends IntegrationTestCase
 
     private function createTracker()
     {
-        $tracker = new \Piwik\Tests\Framework\Mock\Tracker();
+        $tracker = new \Piwik\Plugins\QueuedTracking\tests\Framework\Mock\Tracker();
         return $tracker;
     }
 }


### PR DESCRIPTION
Also includes these changes:
- In tests, use custom forced exception to simulate failure instead of invalid idsite (which is now ignored).
- Has some changes to ProcessorTest that passed a queue to Processor::process() (the method never required a queue as an argument).
