### PR TITLE
Setup embedded tracker environment correctly in queuedtracking:process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,6 @@ before_install:
   - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && export USE_ZEND_ALLOC=0 || true'
 
 install:
-  - '[ ! -f ./tests/travis/install_mysql_5.6.sh ] || ./tests/travis/install_mysql_5.6.sh'
-
-  # Make sure we use Python 2.6
-  - '[ ! -f ./tests/travis/install_python_2.6.sh ] || ./tests/travis/install_python_2.6.sh'
-
   # move all contents of current repo (which contains the plugin) to a new directory
   - mkdir $PLUGIN_NAME
   - cp -R !($PLUGIN_NAME) $PLUGIN_NAME
@@ -56,15 +51,21 @@ install:
   - git clone -q https://github.com/piwik/piwik.git piwik
   - cd piwik
   - git fetch -q --all
+  - git submodule update
+
   # make sure travis-scripts repo is latest for initial travis setup
   - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/piwik/travis-scripts.git ./tests/travis"'
   - cd ./tests/travis ; git checkout master ; cd ../..
-
 
   - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"QueuedTracking\" --verbose"
   - '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
 
   - ./tests/travis/checkout_test_against_branch.sh
+
+  - '[ ! -f ./tests/travis/install_mysql_5.6.sh ] || ./tests/travis/install_mysql_5.6.sh'
+
+  # Make sure we use Python 2.6
+  - '[ ! -f ./tests/travis/install_python_2.6.sh ] || ./tests/travis/install_python_2.6.sh'
 
   - ./tests/travis/configure_git.sh
 


### PR DESCRIPTION
Use Environment instance instead of trying to clear the container and reload tracker plugins / environment in-place.

Should fix #12 

@tsteur Can you test these changes? I'm not currently setup to test/debug QueuedTracking and there aren't any automated tests for this command. Feel free to commit directly to this branch, you'd know better how to apply this change to this plugin.