### PR TITLE
Log requests that take more than 2 seconds

### DIFF
--- a/Queue/Processor.php
+++ b/Queue/Processor.php
@@ -171,7 +171,7 @@ class Processor
     {
         // 2 seconds per tracking request should give it enough time to process it
         $ttl = $requestSet->getNumberOfRequests() * 2;
-        $ttl = max($ttl, 20); // lock for at least 20 seconds
+        $ttl = max($ttl, 30); // lock for at least 30 seconds
 
         return $this->queueManager->expireLock($ttl);
     }

--- a/Queue/Processor/Handler.php
+++ b/Queue/Processor/Handler.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\QueuedTracking\Queue\Processor;
 
+use Piwik\Common;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Tracker;
 use Piwik\Plugins\QueuedTracking\Queue;
@@ -43,7 +44,15 @@ class Handler
 
         foreach ($requestSet->getRequests() as $request) {
             try {
+                $startMs = round(microtime(true) * 1000);
+
                 $tracker->trackRequest($request);
+
+                $diffInMs = round(microtime(true) * 1000) - $startMs;
+                if ($diffInMs > 2000) {
+                    Common::printDebug(sprintf('The following request took more than 2 seconds (%d ms) to be tracked: %s', $diffInMs, var_export($request->getParams(), 1)));
+                }
+
                 $this->count++;
             } catch (UnexpectedWebsiteFoundException $ex) {
                 // empty

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ __Are there any known issues?__
 
 ## Changelog
 
+0.2.6
+- When a request takes more than 2 seconds and debug tracker mode is enabled, log information about the request.
+
 0.2.5
 
 - Use a better random number generator if available on the system to more evenly process queues.


### PR DESCRIPTION
Also increased default ttl to 30 seconds when locking a queue
