### PR TITLE
Unlimited queues

### DIFF
--- a/Queue/Manager.php
+++ b/Queue/Manager.php
@@ -35,34 +35,6 @@ class Manager
 
     private $numRequestsToProcessInBulk = 50;
 
-    /**
-     * This mapping makes sure we move requests more evenly into different queues. Eg if we would do a
-     * ord($firstLetter) instead of this mapping, and have 4 workers, we would move the following characters:
-     * '0, 4, 8, d' into queue 0, '1, 5, 9, a, e' into queue 1, '2, 6, b, f' into queue 2 and '3, 7, c' into queue 3.
-     * This means queue 0 would get way more requests assigned compared to queue 3. It won't be perfect this way eg
-     * when having only 3 workers there will be always one queue with a few more results.
-     *
-     * @var array
-     */
-    private $mappingLettersToNumeric = array(
-        '0' => 0,
-        '1' => 1,
-        '2' => 2,
-        '3' => 3,
-        '4' => 4,
-        '5' => 5,
-        '6' => 6,
-        '7' => 7,
-        '8' => 8,
-        '9' => 9,
-        'a' => 10,
-        'b' => 11,
-        'c' => 12,
-        'd' => 13,
-        'e' => 14,
-        'f' => 15,
-    );
-
     public function __construct(Backend $backend, Lock $lock)
     {
         $this->backend = $backend;
@@ -206,15 +178,11 @@ class Manager
 
     protected function getQueueIdForVisitor($visitorId)
     {
-        $visitorId = strtolower(substr($visitorId, 0, 1));
+        $id = crc32($visitorId);
 
-        if (isset($this->mappingLettersToNumeric[$visitorId])) {
-            $id = $this->mappingLettersToNumeric[$visitorId];
-        } else {
-            $id = ord($visitorId);
-        }
+        $finalId =  $id % $this->numQueuesAvailable;
 
-        return $id % $this->numQueuesAvailable;
+        return $finalId;
     }
 
     public function canAcquireMoreLocks()

--- a/Queue/Manager.php
+++ b/Queue/Manager.php
@@ -66,7 +66,7 @@ class Manager
         return true;
     }
 
-    private function moveRequestsIntoAnotherQueue($queueIdsToMove)
+    public function moveRequestsIntoAnotherQueue($queueIdsToMove)
     {
         foreach ($queueIdsToMove as $queueId) {
             $queue = $this->createQueue($queueId);

--- a/Updates/0.3.3.php
+++ b/Updates/0.3.3.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\QueuedTracking;
+
+use Piwik\Container\StaticContainer;
+use Piwik\Timer;
+use Piwik\Updater;
+use Piwik\Updates;
+
+class Updates_0_3_3 extends Updates
+{
+    public function doUpdate(Updater $updater)
+    {
+        $settings = $this->getSettings();
+        $numQueueWorkers = $settings->numQueueWorkers->getValue();
+
+        // queues are numbered from 0 to (number of queues - 1)
+        $queueIdsToMove = range(0, $numQueueWorkers - 1);
+
+        $backend      = Queue\Factory::makeBackend();
+        $queueManager = Queue\Factory::makeQueueManager($backend);
+
+        $t = new Timer();
+        $t->init();
+
+        $queueManager->moveRequestsIntoAnotherQueue($queueIdsToMove);
+
+        echo $t->getTime();
+    }
+
+    /**
+     * @return Settings
+     */
+    public function getSettings()
+    {
+        return StaticContainer::get('Piwik\Plugins\QueuedTracking\Settings');
+    }
+}

--- a/Updates/0.3.3.php
+++ b/Updates/0.3.3.php
@@ -10,29 +10,27 @@
 namespace Piwik\Plugins\QueuedTracking;
 
 use Piwik\Container\StaticContainer;
-use Piwik\Timer;
+use Piwik\Plugins\QueuedTracking\Queue\Manager;
 use Piwik\Updater;
 use Piwik\Updates;
 
 class Updates_0_3_3 extends Updates
 {
+    /**
+     * @var Manager
+     */
+    protected $queueManager;
+
     public function doUpdate(Updater $updater)
     {
         $settings = $this->getSettings();
         $numQueueWorkers = $settings->numQueueWorkers->getValue();
 
-        // queues are numbered from 0 to (number of queues - 1)
-        $queueIdsToMove = range(0, $numQueueWorkers - 1);
+        if ($numQueueWorkers <= 1) {
+            return; // it is pointless to rewrite one queue to the same queue
+        }
 
-        $backend      = Queue\Factory::makeBackend();
-        $queueManager = Queue\Factory::makeQueueManager($backend);
-
-        $t = new Timer();
-        $t->init();
-
-        $queueManager->moveRequestsIntoAnotherQueue($queueIdsToMove);
-
-        echo $t->getTime();
+        $this->rewriteQueues($numQueueWorkers);
     }
 
     /**
@@ -41,5 +39,69 @@ class Updates_0_3_3 extends Updates
     public function getSettings()
     {
         return StaticContainer::get('Piwik\Plugins\QueuedTracking\Settings');
+    }
+
+    private function rewriteQueues($numQueueWorkers)
+    {
+        // queues are numbered from 0 to (number of queues - 1)
+        $queueIdsToRewrite = range(0, $numQueueWorkers - 1);
+
+        // loading all requests and removing them from queues
+        $requests = $this->loadRequestsFromQueues($queueIdsToRewrite);
+
+        // writes requests to queues using new algorithm
+        $this->writeQueues($requests);
+    }
+
+    /**
+     * @return Manager
+     */
+    private function getQueueManager()
+    {
+        if (!$this->queueManager) {
+            $backend = Queue\Factory::makeBackend();
+            $this->queueManager = Queue\Factory::makeQueueManager($backend);
+        }
+
+        return $this->queueManager;
+    }
+
+    /**
+     * @param array $queueIdsToRewrite
+     * @return array
+     */
+    private function loadRequestsFromQueues(array $queueIdsToRewrite)
+    {
+        $queueManager = $this->getQueueManager();
+
+        $requestsByQueueId = [];
+
+        foreach ($queueIdsToRewrite as $queueId) {
+            $queue = $queueManager->createQueue($queueId);
+
+            $singleQueueRequestsSets = [];
+
+            while ($requestSets = $queue->getRequestSetsToProcess()) {
+                $singleQueueRequestsSets[] = $requestSets;
+                $queue->markRequestSetsAsProcessed();
+            }
+
+            $requestsByQueueId[$queueId] = $singleQueueRequestsSets;
+        }
+
+        return $requestsByQueueId;
+    }
+
+    private function writeQueues(array $requestsByQueueId)
+    {
+        $queueManager = $this->getQueueManager();
+
+        foreach ($requestsByQueueId as $queueId => $requestSets) {
+            foreach ($requestSets as $requestsSubSet) {
+                foreach ($requestsSubSet as $requestSet) {
+                    $queueManager->addRequestSetToQueues($requestSet);
+                }
+            }
+        }
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "QueuedTracking",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "Scale your large traffic Piwik service by queuing tracking requests in Redis for better performance. ",
     "theme": false,
     "keywords": ["tracker", "tracking", "queue", "redis"],

--- a/tests/Integration/Queue/ManagerTest.php
+++ b/tests/Integration/Queue/ManagerTest.php
@@ -119,41 +119,25 @@ class ManagerTest extends IntegrationTestCase
 
     public function test_getQueueIdForVisitor_shouldRespectNumQueuesAvailable()
     {
-        $this->assertQueueIdForVisitorIdEquals(0, '0');
-        $this->assertQueueIdForVisitorIdEquals(1, '1');
-        $this->assertQueueIdForVisitorIdEquals(2, '2');
-        $this->assertQueueIdForVisitorIdEquals(3, '3');
-        $this->assertQueueIdForVisitorIdEquals(0, '4');
-        $this->assertQueueIdForVisitorIdEquals(1, '5');
-        $this->assertQueueIdForVisitorIdEquals(2, '6');
-        $this->assertQueueIdForVisitorIdEquals(3, '7');
+        $this->assertQueueIdForVisitorIdEquals(1, '2044b47c789946d1');
+        $this->assertQueueIdForVisitorIdEquals(3, '76d0d5448a361511');
+        $this->assertQueueIdForVisitorIdEquals(0, '8c82f3727583bd19');
+        $this->assertQueueIdForVisitorIdEquals(1, 'efad5df415b6a1ec');
+        $this->assertQueueIdForVisitorIdEquals(3, '002c8a8527435407');
+        $this->assertQueueIdForVisitorIdEquals(2, '103bc35dd05ecf2d');
+        $this->assertQueueIdForVisitorIdEquals(1, '25c2355bfa4f55d2');
+        $this->assertQueueIdForVisitorIdEquals(0, '2843128ac6a7f239');
 
         $this->manager->setNumberOfAvailableQueues(3);
 
-        $this->assertQueueIdForVisitorIdEquals(0, '0');
-        $this->assertQueueIdForVisitorIdEquals(1, '1');
-        $this->assertQueueIdForVisitorIdEquals(2, '2');
-        $this->assertQueueIdForVisitorIdEquals(0, '3');
-        $this->assertQueueIdForVisitorIdEquals(1, '4');
-        $this->assertQueueIdForVisitorIdEquals(2, '5');
-        $this->assertQueueIdForVisitorIdEquals(0, '6');
-        $this->assertQueueIdForVisitorIdEquals(1, '7');
-    }
-
-    public function test_getQueueIdForVisitor_shouldMoveVisitorIntoQueueBasedOnFirstCharacter()
-    {
-        $numQueues = $this->manager->getNumberOfAvailableQueues();
-
-        $a = 10 % $numQueues; // 10, 11, 12 is a internal mapping see {Manager::$mappingLettersToNumeric}
-        $b = 11 % $numQueues;
-        $c = 12 % $numQueues;
-
-        $this->assertQueueIdForVisitorIdEquals($a, 'a');
-        $this->assertQueueIdForVisitorIdEquals($b, 'b');
-        $this->assertQueueIdForVisitorIdEquals($c, 'c');
-        $this->assertQueueIdForVisitorIdEquals($a, 'abcdef');
-        $this->assertQueueIdForVisitorIdEquals($b, 'bbcdef');
-        $this->assertQueueIdForVisitorIdEquals($c, 'cbcdef');
+        $this->assertQueueIdForVisitorIdEquals(1, '00e0bfc49cfc03d3');
+        $this->assertQueueIdForVisitorIdEquals(2, '083a2a874d54745e');
+        $this->assertQueueIdForVisitorIdEquals(1, '240a7009f9fb31b9');
+        $this->assertQueueIdForVisitorIdEquals(2, '6de0339f134685c5');
+        $this->assertQueueIdForVisitorIdEquals(0, '7b092c476316f0dc');
+        $this->assertQueueIdForVisitorIdEquals(2, 'f196ef9e45d9627a');
+        $this->assertQueueIdForVisitorIdEquals(0, 'ce5c055abf96abd0');
+        $this->assertQueueIdForVisitorIdEquals(2, 'be4d1f0c8f8749b5');
     }
 
     public function test_getAllQueues_shouldReturnAnArrayOfQueueInstances()
@@ -267,9 +251,9 @@ class ManagerTest extends IntegrationTestCase
         }
 
         $this->assertSame(26, $this->manager->getNumberOfRequestSetsInAllQueues());
-        $this->assertNumberOfRequestSetsInQueueEquals(5,  $queueId = 0);
-        $this->assertNumberOfRequestSetsInQueueEquals(10, $queueId = 1);
-        $this->assertNumberOfRequestSetsInQueueEquals(1,  $queueId = 2);
+        $this->assertNumberOfRequestSetsInQueueEquals(9,  $queueId = 0);
+        $this->assertNumberOfRequestSetsInQueueEquals(3, $queueId = 1);
+        $this->assertNumberOfRequestSetsInQueueEquals(4,  $queueId = 2);
         $this->assertNumberOfRequestSetsInQueueEquals(10, $queueId = 3);
         $this->assertNumberOfRequestSetsInQueueEquals(0,  $queueId = 4); // this queue is not available
     }
@@ -286,13 +270,13 @@ class ManagerTest extends IntegrationTestCase
         }
 
         $this->assertSame(26, $this->manager->getNumberOfRequestSetsInAllQueues());
-        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 0);
-        $this->assertNumberOfRequestSetsInQueueEquals(26, $queueId = 1);
+        $this->assertNumberOfRequestSetsInQueueEquals(26, $queueId = 0);
+        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 1);
         $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 2);
         $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 3);
 
         // verify all 26 written into queue
-        $this->assertRequestSetsInQueueEquals($expectedRequestSets, 1);
+        $this->assertRequestSetsInQueueEquals($expectedRequestSets, 0);
     }
 
     public function test_addRequestSetToQueues_shouldMoveAllInSameQueue_IfAllHaveSameUidAndTheyAreInOneRequestSet()
@@ -302,13 +286,13 @@ class ManagerTest extends IntegrationTestCase
         $this->manager->addRequestSetToQueues($requestSet);
 
         $this->assertSame(1, $this->manager->getNumberOfRequestSetsInAllQueues());
-        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 0);
-        $this->assertNumberOfRequestSetsInQueueEquals(1, $queueId = 1);
+        $this->assertNumberOfRequestSetsInQueueEquals(1, $queueId = 0);
+        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 1);
         $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 2);
         $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 3);
 
         // verify all 15 written into queue
-        $this->assertRequestSetsInQueueEquals(array($requestSet), 1);
+        $this->assertRequestSetsInQueueEquals(array($requestSet), 0);
     }
 
     public function test_addRequestSetToQueues_shouldMoveIntoDifferentQueues_IfThereAreManyDifferentRequestsInOneSet()
@@ -328,19 +312,20 @@ class ManagerTest extends IntegrationTestCase
 
         $this->manager->addRequestSetToQueues($req);
 
-        $this->assertSame(3, $this->manager->getNumberOfRequestSetsInAllQueues()); // 3 different uid
+        // uids from requests should
+        $this->assertSame(2, $this->manager->getNumberOfRequestSetsInAllQueues());
 
-        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 0);
-        $this->assertNumberOfRequestSetsInQueueEquals(1, $queueId = 1);
-        $this->assertNumberOfRequestSetsInQueueEquals(1, $queueId = 2);
+        $this->assertNumberOfRequestSetsInQueueEquals(1, $queueId = 0);
+        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 1);
+        $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 2);
         $this->assertNumberOfRequestSetsInQueueEquals(1, $queueId = 3);
         $this->assertNumberOfRequestSetsInQueueEquals(0, $queueId = 4);
 
         $req->setRequests(array($requests[1]));
-        $this->assertRequestSetsInQueueEquals($req, 1);
+        $this->assertRequestSetsInQueueEquals($req, 0);
 
         $req->setRequests(array($requests[3]));
-        $this->assertRequestSetsInQueueEquals($req, 2);
+        $this->assertRequestSetsInQueueEquals($req, 3);
 
         $req->setRequests(array($requests[0], $requests[2], $requests[4], $requests[5]));
         $this->assertRequestSetsInQueueEquals($req, 3);

--- a/tests/Integration/Tracker/HandlerTest.php
+++ b/tests/Integration/Tracker/HandlerTest.php
@@ -214,8 +214,8 @@ class HandlerTest extends IntegrationTestCase
         // verify
         $this->queue->setNumberOfRequestsToProcessAtSameTime(2);
 
-        // those requests  will be written into queue 1
-        $requestSet = $this->queue->createQueue($id = 1)->getRequestSetsToProcess();
+        // those requests  will be written into queue 3
+        $requestSet = $this->queue->createQueue($id = 3)->getRequestSetsToProcess();
         $this->assertCount(2, $requestSet);
 
         $requests = $requestSet[0]->getRequests();


### PR DESCRIPTION
**Note**: this is mirror PR that was closed in piwik/plugin-QueuedTracking

Current queue number assigning on a basis of first character of visitorId limits number of queues to 16. Using crc32 hash instead removes such limitation. I've made some tests to check requests distribution among queues. Tests were based on first 1000 visitorIds from real piwik data. To measure how well requests are distributed I have used coefficient of variation (CV, the lower, the better). The results are as follows:

```
On a basis of first character:
CV: 0.78363767137626

crc32:
CV: 0.10465180361561
```

I have also some results of tracking with 64 queues and big amount of data:

```
4094848
(111223+62240+92339+34140+64897+17709+21326+88343+77872+95449+77885+18104+61122+33417+30644+25662+46642+54413+82470+65691+99934+17979+80590+39032+47643+30838+82564+58470+85142+19618+91224+70346+79080+43460+32920+79150+87681+101721+60071+82587+90269+65400+68967+80579+32645+51592+62546+68701+89217+97485+120839+91355+100002+66549+37623+69790+25402+68226+79828+56177+78381+21943+72492+47202) request sets left in queue
```

CV is this case is 0.40857983821982 and from tests it looks it is acceptable (no problems occured during tests).

If this solution is acceptable for Piwik developers, another question is what should happen with validation of number of workers in plugin's settings. In my opinion it is safe to enhance upper limit to 64 (as this value was tested), or even remove upper limit.
