### PR TITLE
Make Mysql backend work with mysqli in tracker mode

### DIFF
--- a/tests/Integration/Queue/Backend/MysqlTest.php
+++ b/tests/Integration/Queue/Backend/MysqlTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\QueuedTracking\tests\Integration\Queue\Backend;
 
+use Piwik\Db;
 use Piwik\Plugins\QueuedTracking\Queue\Backend\MySQL;
 use Piwik\Plugins\QueuedTracking\Queue\Backend\Redis;
 use \Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -35,6 +36,10 @@ class MysqlTest extends IntegrationTestCase
             parent::setUp();
         }
 
+        // ensure tracker DB will be used
+        Db::destroyDatabaseObject();
+        $GLOBALS['PIWIK_TRACKER_MODE'] = true;
+
         $this->backend = $this->createMysqlBackend();
 
         if (!$this->hasDependencies()) {
@@ -43,6 +48,13 @@ class MysqlTest extends IntegrationTestCase
             $this->backend->delete($this->key);
             $this->backend->appendValuesToList($this->listKey, array(10, 299, '34'));
         }
+    }
+
+    public function tearDown()
+    {
+        $GLOBALS['PIWIK_TRACKER_MODE'] = false;
+        Db::destroyDatabaseObject();
+        parent::tearDown();
     }
 
     protected function flushBackend()


### PR DESCRIPTION
Turns out Mysqli is once more behaving differently in tracker mode vs regular mode... As the backend is used in tracker mode, tests will now be executed in tracker mode. 

There were few differences in the query method eg it doesn't return a statement but a `true/false` whether query succeeded.

fixes #83 
