### PR TITLE
Retry deadlocked sql queries

### DIFF
--- a/Queue/Processor.php
+++ b/Queue/Processor.php
@@ -144,7 +144,12 @@ class Processor
                         if (!empty($requestSetsToRetry)) {
                             Common::printDebug('Need to retry ' . count($queuedRequestSets) . ' request sets.');
                         }
-                        $this->processRequestSets($tracker, $requestSetsToRetry);
+
+                        $failedRequestSets = $this->processRequestSets($tracker, $requestSetsToRetry);
+                        if (!empty($failedRequestSets)) {
+                            Common::printDebug('Failed processing ' . count($failedRequestSets) . ' request sets.');
+                        }
+
                         $queue->markRequestSetsAsProcessed();
                         // TODO if markR..() fails, we would process them again later
                     }


### PR DESCRIPTION
If a SQL deadlock occurs, this change tries again one more time.
This helps to avoid data loss on bigger setups with lots of writes to "piwik_log_visit".

On my setup I can observe a deadlock of two "UPDATE piwik_log_visit" queries about every 10 minutes during high load.

I also added logging for the case where it fails a second time, so we can observe how much data is lost forever (currently I have none of such cases in my logs).