### PR TITLE
Add new option to process command to customise how many requests should be processed in at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+4.0.2
+- Support new option `--force-num-requests-process-at-once` to the process command
+
 4.0.1
 - Improve compatibility with PHP 7.4
 


### PR DESCRIPTION
Can be useful in various situations. Needing this on our cloud.

Overwrites this value
![image](https://user-images.githubusercontent.com/273120/94503554-36d6d980-0263-11eb-95b6-b5d8b132411e.png)
