### PR TITLE
Ensure console commands return integers

### DIFF
--- a/Commands/LockStatus.php
+++ b/Commands/LockStatus.php
@@ -61,5 +61,7 @@ class LockStatus extends ConsoleCommand
                 $output->writeln(' ');
             }
         }
+
+        return 0;
     }
 }

--- a/Commands/Monitor.php
+++ b/Commands/Monitor.php
@@ -89,6 +89,7 @@ class Monitor extends ConsoleCommand
             sleep(2);
         }
 
+        return 0;
     }
 
     /**

--- a/Commands/PrintQueuedRequests.php
+++ b/Commands/PrintQueuedRequests.php
@@ -57,5 +57,7 @@ class PrintQueuedRequests extends ConsoleCommand
             $output->writeln(sprintf('<info>These were the requests of queue %s. Use <comment>--queue-id=%s</comment> to print only information for this queue.</info>', $thisQueueId, $thisQueueId));
 
         }
+
+        return 0;
     }
 }

--- a/Commands/Process.php
+++ b/Commands/Process.php
@@ -94,6 +94,8 @@ class Process extends ConsoleCommand
         $trackerEnvironment->destroy();
 
         $this->writeSuccessMessage($output, array(sprintf('This worker finished queue processing with %sreq/s (%s requests in %02.2f seconds)', $requestsPerSecond, $numRequestsTracked, $neededTime)));
+
+        return 0;
     }
 
     private function getNumberOfRequestsPerSecond($numRequestsTracked, $neededTimeInSeconds)

--- a/Commands/Test.php
+++ b/Commands/Test.php
@@ -208,6 +208,8 @@ class Test extends ConsoleCommand
 
         $output->writeln('');
         $output->writeln('<comment>Done</comment>');
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
### Description:

Newer versions of symfony console will throw an error when a console command does not return an integer.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
