### PR TITLE
[Vue] error notfiications for ajaxhelper.ts go into #ajaxErrors

### DIFF
--- a/tests/UI/QueuedTrackingSettings_spec.js
+++ b/tests/UI/QueuedTrackingSettings_spec.js
@@ -46,7 +46,7 @@ describe("QueuedTrackingSettings", function () {
             $('.card-content:contains(\'QueuedTracking\')').show();
         });
         await page.mouse.move(-10, -10);
-        expect(await page.screenshotSelector(selector + ',#notificationContainer')).to.matchImage('settings_save_error');
+        expect(await page.screenshotSelector(selector + ',#ajaxError,#notificationContainer')).to.matchImage('settings_save_error');
     });
 
     it("should display the settings page with sentinel enabled", async function () {


### PR DESCRIPTION
### Description:

Refs https://github.com/matomo-org/matomo/pull/18446

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
