### PR TITLE
Only flush entries of the currently selected DB

### DIFF
--- a/Queue/Backend/Redis.php
+++ b/Queue/Backend/Redis.php
@@ -247,7 +247,7 @@ end';
     public function flushAll()
     {
         $this->connectIfNeeded();
-        $this->redis->flushAll();
+        $this->redis->flushDB();
     }
 
     private function connectIfNeeded()


### PR DESCRIPTION
refs https://github.com/matomo-org/plugin-QueuedTracking/issues/167

[flushAll](https://redis.io/commands/flushall/) would delete all keys from all DBs, not just the currently selected one.

While [flushDB](https://redis.io/commands/flushdb/) would only flush the keys of the current DB.

Note this method is only used in tests so it won't resolve any actual issue.
  
### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
