### PR TITLE
Improve request tracking error handling

### DIFF
--- a/Configuration.php
+++ b/Configuration.php
@@ -16,6 +16,8 @@ class Configuration
     const DEFAULT_NOTIFY_THRESHOLD = 250000;
     const KEY_NOTIFY_EMAILS = 'notify_queue_threshold_emails';
     const KEY_NOTIFY_THRESHOLD = 'notify_queue_threshold_single_queue';
+    const LOG_FAILED_TRACKING_REQUESTS = 'log_failed_tracking_request_body';
+    const LOG_FAILED_TRACKING_REQUESTS_DEFAULT = 0;
 
     public function install()
     {
@@ -74,6 +76,11 @@ class Configuration
         }
 
         return $value;
+    }
+
+    public function shouldLogFailedTrackingRequestsBody(): bool
+    {
+        return (bool) $this->getConfigValue(self::LOG_FAILED_TRACKING_REQUESTS, self::LOG_FAILED_TRACKING_REQUESTS_DEFAULT);
     }
 
     private function getConfig()

--- a/Queue/Processor/Handler.php
+++ b/Queue/Processor/Handler.php
@@ -56,7 +56,10 @@ class Handler
                 // empty
             } catch (\Throwable $th) {
                 // Log the error to help with debugging and visibility
-                $message = "There was an error while trying to process a queued tracking request.\nError:\n" . $th->getMessage() . "\nStack trace:\n" . $th->getTraceAsString();
+                $message = "There was an error while trying to process a queued tracking request.";
+                $message .= "\nError:\n" . $th->getMessage() . "\nStack trace:\n" . $th->getTraceAsString();
+                $message .= "\nFailed request:\n" . base64_encode(gzcompress(json_encode($request->getRawParams())));
+                $message .= "\nFailed request set:\n" . base64_encode(gzcompress(json_encode($requestSet->getState())));
                 StaticContainer::get(\Psr\Log\LoggerInterface::class)->warning($message);
 
                 // Wrap any throwables so that they are caught by the try/catch in Processor, which is expecting Exceptions

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,6 +114,11 @@ __How can I debug in case something goes wrong?__
 * Enable tracker debug mode in `config.ini.php` via `[Tracker] debug=1` if processing requests during tracking is enabled.
 * Use the command `./console queuedtracking:print-queued-requests` to view the next requests to process in each queue. If you execute this command twice within 1-10 minutes, and it outputs the same, the queue is not being processed most likely indicating a problem.
 * You can add the tracking parameter `&queuedtracking=0` to the tracking request to insert a tracking request directly into the database instead of into the queued tracking handler
+* Plugin version 4.0.7 and greater logs a warning level message containing the error and has a new `log_failed_tracking_request_body` configuration. The new config is only for debugging purposes as always recording the request body for failed requests could be a privacy concern and considerably increase the size of the log file. To use the config, you would edit your `config/config.ini.php` to look something like the following:
+```
+[QueuedTracking]
+log_failed_tracking_request_body = 1
+```
 
 __I am using the Log Importer in combination with Queued Tracking, is there something to consider?__
 

--- a/tests/Integration/Queue/ProcessorTest.php
+++ b/tests/Integration/Queue/ProcessorTest.php
@@ -14,6 +14,7 @@ use Piwik\Tracker\TrackerConfig;
 use Piwik\Tracker;
 use Piwik\Plugins\QueuedTracking\Queue;
 use Piwik\Plugins\QueuedTracking\Queue\Processor;
+use Piwik\Version;
 
 class TestProcessor extends Processor {
 
@@ -221,7 +222,8 @@ class ProcessorTest extends IntegrationTestCase
         $this->acquireAllQueueLocks();
         $requestSetsToRetry = $this->processor->processRequestSets($tracker, $queuedRequestSets);
 
-        $expectedSets = [$requestSet1, $requestSet2];
+        // I couldn't find a param other than uadata that could throw a TypeError and it's not used in older versions
+        $expectedSets = version_compare(Version::VERSION, '4.12.0', '>') ? [$requestSet1, $requestSet2] : [];
         $this->assertEquals($expectedSets, $requestSetsToRetry);
 
         // verify request set 2 contains only valid ones

--- a/tests/Integration/Queue/ProcessorTest.php
+++ b/tests/Integration/Queue/ProcessorTest.php
@@ -223,13 +223,19 @@ class ProcessorTest extends IntegrationTestCase
         $requestSetsToRetry = $this->processor->processRequestSets($tracker, $queuedRequestSets);
 
         // I couldn't find a param other than uadata that could throw a TypeError and it's not used in older versions
-        $isOlderMatomo = version_compare(Version::VERSION, '4.12.0', '>');
-        $expectedSets = $isOlderMatomo ? [$requestSet1, $requestSet2] : [];
-        $expectedRequestCount = $isOlderMatomo ? 1 : 2;
+        $isNewerMatomo = version_compare(Version::VERSION, '4.12.0', '>');
+        $expectedSets = $isNewerMatomo ? [$requestSet1, $requestSet2] : [];
+        $expectedRequestCount = $isNewerMatomo ? 1 : 2;
         $this->assertEquals($expectedSets, $requestSetsToRetry);
 
         // verify request set 2 contains only valid ones
         $this->assertCount($expectedRequestCount, $requestSet2->getRequests());
+
+        // If the requests to retry isn't empty, run it again and make sure there's nothing to retry
+        if (!empty($requestSetsToRetry)) {
+            $requestSetsToRetry = $this->processor->processRequestSets($tracker, $requestSetsToRetry);
+            $this->assertEquals([], $requestSetsToRetry);
+        }
     }
 
     public function test_processRequestSets_ShouldReturnAnEmptyArray_IfNoRequestSetsAreGiven()

--- a/tests/Integration/Queue/ProcessorTest.php
+++ b/tests/Integration/Queue/ProcessorTest.php
@@ -223,11 +223,13 @@ class ProcessorTest extends IntegrationTestCase
         $requestSetsToRetry = $this->processor->processRequestSets($tracker, $queuedRequestSets);
 
         // I couldn't find a param other than uadata that could throw a TypeError and it's not used in older versions
-        $expectedSets = version_compare(Version::VERSION, '4.12.0', '>') ? [$requestSet1, $requestSet2] : [];
+        $isOlderMatomo = version_compare(Version::VERSION, '4.12.0', '>');
+        $expectedSets = $isOlderMatomo ? [$requestSet1, $requestSet2] : [];
+        $expectedRequestCount = $isOlderMatomo ? 1 : 2;
         $this->assertEquals($expectedSets, $requestSetsToRetry);
 
         // verify request set 2 contains only valid ones
-        $this->assertCount(1, $requestSet2->getRequests());
+        $this->assertCount($expectedRequestCount, $requestSet2->getRequests());
     }
 
     public function test_processRequestSets_ShouldReturnAnEmptyArray_IfNoRequestSetsAreGiven()


### PR DESCRIPTION
### Description:

Some errors weren't getting caught properly and were preventing the queue from processing all the other requests. This improvement should resolve that issue.
Fixes: #194 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
