### PR TITLE
Fix random integration test failure due to timestamp roll over

### DIFF
--- a/tests/Integration/QueueTest.php
+++ b/tests/Integration/QueueTest.php
@@ -65,14 +65,26 @@ class QueueTest extends IntegrationTestCase
 
         $this->assertTrue($this->buildRequestSetWithIdSite(3) instanceof RequestSet);
 
-        $this->assertEquals(array(
-            new Request(array('idsite' => 1)),
-            new Request(array('idsite' => 2)),
-            new Request(array('idsite' => 3)),
-        ), $this->buildRequestSetWithIdSite(3)->getRequests());
+        $expected = [
+            new Request(['idsite' => 1]),
+            new Request(['idsite' => 2]),
+            new Request(['idsite' => 3]),
+        ];
+
+        $actual = $this->buildRequestSetWithIdSite(3)->getRequests();
+
+        $this->assertEquals($this->removeTimestamps($expected), $this->removeTimestamps($actual));
 
         $this->assertTrue($this->buildRequestSetWithIdSite(10) instanceof RequestSet);
         $this->assertCount(10, $this->buildRequestSetWithIdSite(10)->getRequests());
+    }
+
+    private function removeTimestamps(array $array): array
+    {
+        foreach ($array as $request) {
+            unset($request->timestamp);
+        }
+        return $array;
     }
 
     public function test_internalBuildRequestsSet_ShouldBeAbleToSpecifyTheSiteId()

--- a/tests/Integration/QueueTest.php
+++ b/tests/Integration/QueueTest.php
@@ -73,16 +73,16 @@ class QueueTest extends IntegrationTestCase
 
         $actual = $this->buildRequestSetWithIdSite(3)->getRequests();
 
-        $this->assertEquals($this->removeTimestamps($expected), $this->removeTimestamps($actual));
+        $this->assertEquals($this->setTimestamps($expected), $this->setTimestamps($actual));
 
         $this->assertTrue($this->buildRequestSetWithIdSite(10) instanceof RequestSet);
         $this->assertCount(10, $this->buildRequestSetWithIdSite(10)->getRequests());
     }
 
-    private function removeTimestamps(array $array): array
+    private function setTimestamps(array $array): array
     {
         foreach ($array as $request) {
-            unset($request->timestamp);
+            $request->setCurrentTimestamp(1);
         }
         return $array;
     }


### PR DESCRIPTION
### Description:

The following test randomly fails when the timestamp rolls over between generation of the first set of data and the second

```
1) Piwik\Plugins\QueuedTracking\tests\Integration\QueueTest::
   test_internalBuildRequestsSet_ShouldReturnRequestObjects
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
         'isAuthenticated' => null
         'isEmptyRequest' => false
         'tokenAuth' => false
-        'timestamp' => 1687386976
+        'timestamp' => 1687386977
         'requestMetadata' => Array ()
         'customTimestampDoesNotRequireTokenauthWhenNewerThan' => 86400
     )

/home/runner/work/matomo/matomo/matomo/plugins/QueuedTracking/tests/Integration/
QueueTest.php:72
```
The PR removed the timestamps from the objects before comparison to prevent test failures caused by timestamp differences.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
