### PR TITLE
Fix random integration test failure due to timestamp roll over

### DIFF
--- a/tests/Integration/QueueTest.php
+++ b/tests/Integration/QueueTest.php
@@ -79,27 +79,23 @@ class QueueTest extends IntegrationTestCase
         $this->assertCount(10, $this->buildRequestSetWithIdSite(10)->getRequests());
     }
 
-    private function setTimestamps(array $array): array
-    {
-        foreach ($array as $request) {
-            $request->setCurrentTimestamp(1);
-        }
-        return $array;
-    }
-
     public function test_internalBuildRequestsSet_ShouldBeAbleToSpecifyTheSiteId()
     {
-        $this->assertEquals(array(
-            new Request(array('idsite' => 2)),
-            new Request(array('idsite' => 2)),
-            new Request(array('idsite' => 2)),
-        ), $this->buildRequestSetWithIdSite(3, 2)->getRequests());
+        $expected = [
+            new Request(['idsite' => 2]),
+            new Request(['idsite' => 2]),
+            new Request(['idsite' => 2]),
+        ];
+
+        $actual = $this->buildRequestSetWithIdSite(3, 2)->getRequests();
+
+        $this->assertEquals($this->setTimestamps($expected), $this->setTimestamps($actual));
     }
 
     public function test_internalBuildManyRequestsContainingRequests_ShouldReturnManyRequestObjects()
     {
         $this->assertEquals(array(), $this->buildManyRequestSets(0));
-        $this->assertEquals(array($this->buildRequestSetWithIdSite(1)), $this->buildManyRequestSets(1));
+        $this->assertManyRequestSetsAreEqual(array($this->buildRequestSetWithIdSite(1)), $this->buildManyRequestSets(1));
 
         $this->assertManyRequestSetsAreEqual(array(
             $this->buildRequestSetWithIdSite(1),
@@ -350,4 +346,11 @@ class QueueTest extends IntegrationTestCase
         }
     }
 
+    private function setTimestamps(array $array): array
+    {
+        foreach ($array as $request) {
+            $request->setCurrentTimestamp(1);
+        }
+        return $array;
+    }
 }


### PR DESCRIPTION
### Description:

After #218 there is a second test that randomly fails due to a roll over in a timestamp:

```
1) Piwik\Plugins\QueuedTracking\tests\Integration\QueueTest::test_internalBuildRequestsSet_ShouldBeAbleToSpecifyTheSiteId
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
         'isAuthenticated' => null
         'isEmptyRequest' => false
         'tokenAuth' => false
-        'timestamp' => 1695759228
+        'timestamp' => 1695759229
         'requestMetadata' => Array ()
         'customTimestampDoesNotRequireTokenauthWhenNewerThan' => 86400
     )

/home/runner/work/matomo/matomo/matomo/plugins/QueuedTracking/tests/Integration/QueueTest.php:92
```

Resetting the timestamp as in aforementioned PR should solve that issue.

The second changed test is more a preventive measure. Using `assertManyRequestSetsAreEqual` (and the nested `assertRequestsAreEqual`) should take care of minute differences in timestamps.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
