### PR TITLE
Added code to skip maxmemory config check when --skip-max-memory-config-check=1, #149

### DIFF
--- a/Commands/Test.php
+++ b/Commands/Test.php
@@ -30,6 +30,7 @@ class Test extends ConsoleCommand
     protected function configure()
     {
         $this->setName('queuedtracking:test');
+        $this->addRequiredValueOption('skip-max-memory-config-check', null, 'Do not check for MaxMemory config values ');
         $this->setDescription('Test your Redis connection get some information about your current system.');
     }
 
@@ -48,9 +49,12 @@ class Test extends ConsoleCommand
 
     protected function doExecute(): int
     {
+        $input = $this->getInput();
         $output = $this->getOutput();
         $trackerEnvironment = new Environment('tracker');
         $trackerEnvironment->init();
+
+        $shouldSkipCheckingMemoryConfigValues = $input->getOption('skip-max-memory-config-check');
 
         $settings = Queue\Factory::getSettings();
         $isUsingRedis = $settings->isRedisBackend();
@@ -102,7 +106,7 @@ class Test extends ConsoleCommand
         $output->writeln('Memory: ' . var_export($backend->getMemoryStats(), 1));
 
         $redis = $backend->getConnection();
-        if ($isUsingRedis) {
+        if ($isUsingRedis && !$shouldSkipCheckingMemoryConfigValues) {
 
             $evictionPolicy = $this->getRedisConfig($redis, 'maxmemory-policy');
             $output->writeln('MaxMemory Eviction Policy config: ' . $evictionPolicy);


### PR DESCRIPTION
### Description:

Added code to skip maxmemory config check when `--skip-max-memory-config-check=1`
Fixes: #149

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
