### PR TITLE
Fix unable to configure redis socket with port 0, #PG-3714

### DIFF
--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -151,11 +151,11 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
                 $self->checkMultipleServersOnlyConfiguredWhenSentinelIsEnabled($value);
 
                 if (!$self->isUsingSentinelBackend()) {
-                    (new NumberRange(1, 65535))->validate($value);
+                    (new NumberRange(0, 65535))->validate($value);
                 } else {
                     $ports = explode(',', $value);
                     foreach ($ports as $port) {
-                        (new NumberRange(1, 65535))->validate(trim($port));
+                        (new NumberRange(0, 65535))->validate(trim($port));
                     }
                 }
             };

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -50,9 +50,9 @@ class SettingsTest extends IntegrationTestCase
     public function test_redisPort_ShouldFail_IfPortIsTooLow()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The value needs to be at least 1');
+        $this->expectExceptionMessage('The value needs to be at least 0');
 
-        $this->settings->redisPort->setValue(0);
+        $this->settings->redisPort->setValue(-1);
     }
 
     public function test_redisPort_ShouldFail_IfPortIsTooHigh()
@@ -61,6 +61,12 @@ class SettingsTest extends IntegrationTestCase
         $this->expectExceptionMessage('The value should be at most 65535');
 
         $this->settings->redisPort->setValue(65536);
+    }
+
+    public function test_redisPort_ShouldNotFail_IfPortIsZero()
+    {
+        $this->settings->redisPort->setValue(0);
+        $this->assertEquals(0, $this->settings->redisPort->getValue());
     }
 
     public function test_redisTimeout_ShouldFail_IfTooLong()
@@ -250,8 +256,8 @@ class SettingsTest extends IntegrationTestCase
     public function test_redisPort_ShouldNotFailAndConvertToIntWhenMultipleValuesGiven_IfSentinelIsEnabled()
     {
         $this->enableRedisSentinel();
-        $this->settings->redisPort->setValue('55 , 44.34 ');
-        $this->assertSame('55,44', $this->settings->redisPort->getValue());
+        $this->settings->redisPort->setValue('55 , 44.34, 0 ');
+        $this->assertSame('55,44,0', $this->settings->redisPort->getValue());
     }
 
     public function test_redisPort_ShouldValidateEachPortSeparately_WhenManySpecified()
@@ -260,7 +266,7 @@ class SettingsTest extends IntegrationTestCase
         $this->expectExceptionMessage('The value is not a number');
 
         $this->enableRedisSentinel();
-        $this->settings->redisPort->setValue('55 , 44.34, 4mk ');
+        $this->settings->redisPort->setValue('55, 0 , 44.34, 4mk ');
         $this->assertSame('55,44', $this->settings->redisPort->getValue());
     }
 


### PR DESCRIPTION
### Description:

Fix unable to configure redis socket with port 0
Fixes: #PG-3714, #248

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
