### PR TITLE
Fixes fatal error on Windows due to readline_callback_handler_install method not present, #269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+5.1.0 - 2021-10-22
+- Fixes fatal error on Windows due to readline_callback_handler_install method not present
+
 5.1.0 - 2021-10-21
 - Increased number of queue tracking workers to 4096
 - Enhance queue monitor and process commands

--- a/Commands/Monitor.php
+++ b/Commands/Monitor.php
@@ -71,8 +71,10 @@ class Monitor extends ConsoleCommand
         $qPerPAge       = min(max($this->getPerPageFromArg(), 1), $qCount);
         $qPageCount     = ceil($qCount / $qPerPAge);
 
-        readline_callback_handler_install('', function () {
-        });
+        if (function_exists('readline_callback_handler_install')) {
+            readline_callback_handler_install('', function () {
+            });
+        }
         stream_set_blocking(STDIN, false);
 
         $output->writeln(str_repeat("-", 30));

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "QueuedTracking",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "description": "Scale your large traffic Matomo service by queuing tracking requests in Redis or MySQL for better performance and reliability when experiencing peaks.",
     "theme": false,
     "keywords": ["tracker", "tracking", "queue", "redis"],


### PR DESCRIPTION
### Description:

Fixes fatal error on Windows due to readline_callback_handler_install method not present
Fixes: #269

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
