### PR TITLE
disable monitor interactive paging on windows #269

### DIFF
--- a/Commands/Monitor.php
+++ b/Commands/Monitor.php
@@ -264,13 +264,5 @@ class Monitor extends ConsoleCommand
     private function interactiveCapability()
     {
         return function_exists('readline_callback_handler_install');
-            return false;
-        }
-        
-        if (function_exists('readline_callback_handler_install') == false) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/Commands/Monitor.php
+++ b/Commands/Monitor.php
@@ -75,9 +75,10 @@ class Monitor extends ConsoleCommand
         $qCount         = count($queues);
         $qPerPAge       = min(max($this->getPerPageFromArg(), 1), $qCount);
         $qPageCount     = ceil($qCount / $qPerPAge);
-        
+
         if ($this->interactiveCapability()) {
-            readline_callback_handler_install('', function () {});
+            readline_callback_handler_install('', function () {
+            });
             stream_set_blocking(STDIN, false);
         }
 
@@ -126,7 +127,7 @@ class Monitor extends ConsoleCommand
                 $output->writeln("<fg=black;bg=white;options=bold>" . str_pad(" " . ($qCount) . " Q", 10) . " | " . str_pad(number_format($sumInQueue) . " R", 16) . "</>");
                 $output->writeln(str_repeat("-", 30));
                 $output->writeln(sprintf(
-                    "Q [%s-%s] | <info>page %s/%s</>" . ($this->interactiveCapability() ? " | <comment>press (0-9.,q) or arrow(L,R,U,D)</>" : " | <error>use -p arg to jump to specific page</>"). " | diff/sec %s         \n" .
+                    "Q [%s-%s] | <info>page %s/%s</>" . ($this->interactiveCapability() ? " | <comment>press (0-9.,q) or arrow(L,R,U,D)</>" : " | <error>use -p arg to jump to specific page</>") . " | diff/sec %s         \n" .
                     "%s used memory (%s peak). <info>%d</> workers active." . str_repeat(" ", 15),
                     ($idx - $qPerPAge + 1),
                     $idx,

--- a/Commands/Monitor.php
+++ b/Commands/Monitor.php
@@ -263,7 +263,7 @@ class Monitor extends ConsoleCommand
      */
     private function interactiveCapability()
     {
-        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+        return function_exists('readline_callback_handler_install');
             return false;
         }
         


### PR DESCRIPTION
### Description:
disable monitor interactive paging on Windows environment 
Fixes: #269 

this PR will cause the monitor feature to have different behaviour between Windows and Linux.
please advise, are these different conditions allowed or not? if not allowed, i will adjust the code to remove the interactive paging feature altogether.

---

- the new `-r` parameter replace the old `-p`
- while `-p` now used to jump to specific page

**for example (if we have 16 queue workers):**
-  `php console queuedtracking:monitor` will display 16 rows per page (only 1 page)
- `php console queuedtracking:monitor -r 3` will display 3 rows per page (6 pages total)
- `php console queuedtracking:monitor -r 3 -p 2`  will display 3 rows per page and jump to 2nd page
- `php console queuedtracking:monitor -r 3 -p 6`  will display 3 rows per page and jump to 6th page

`-r` and `-p` will work both on Windows or Linux, but only Linux has the ability to move pages interactively.

@AltamashShaikh @snake14 do you have any other suggestions?
