### PR TITLE
Optimize Redis backend with EVALSHA for Lua scripts

### DIFF
--- a/Queue/Backend/Redis.php
+++ b/Queue/Backend/Redis.php
@@ -15,6 +15,21 @@ use Piwik\Plugins\QueuedTracking\Queue\Backend;
 
 class Redis implements Backend
 {
+    private static $deleteScriptSha1 = null;
+    private static $expireScriptSha1 = null;
+
+    private const DELETE_SCRIPT_CONTENT = 'if redis.call("GET",KEYS[1]) == ARGV[1] then
+    return redis.call("DEL",KEYS[1])
+else
+    return 0
+end';
+
+    private const EXPIRE_SCRIPT_CONTENT = 'if redis.call("GET",KEYS[1]) == ARGV[1] then
+    return redis.call("EXPIRE",KEYS[1], ARGV[2])
+else
+    return 0
+end';
+
     /**
      * @var \Redis
      */
@@ -195,20 +210,18 @@ class Redis implements Backend
 
         $this->connectIfNeeded();
 
-        // see http://redis.io/topics/distlock
-        $script = 'if redis.call("GET",KEYS[1]) == ARGV[1] then
-    return redis.call("DEL",KEYS[1])
-else
-    return 0
-end';
+        if (self::$deleteScriptSha1 === null) {
+            self::$deleteScriptSha1 = sha1(self::DELETE_SCRIPT_CONTENT);
+        }
 
-        // ideally we would use evalSha to reduce bandwidth!
-        return (bool) $this->evalScript($script, array($key), array($value));
-    }
-
-    protected function evalScript($script, $keys, $args)
-    {
-        return $this->redis->eval($script, array_merge($keys, $args), count($keys));
+        try {
+            return (bool) $this->redis->evalSha(self::$deleteScriptSha1, array($key, $value), 1);
+        } catch (\RedisException $e) {
+            if (strpos($e->getMessage(), 'NOSCRIPT') !== false) {
+                return (bool) $this->redis->eval(self::DELETE_SCRIPT_CONTENT, array($key, $value), 1);
+            }
+            throw $e;
+        }
     }
 
     public function getKeysMatchingPattern($pattern)
@@ -226,13 +239,18 @@ end';
 
         $this->connectIfNeeded();
 
-        $script = 'if redis.call("GET",KEYS[1]) == ARGV[1] then
-    return redis.call("EXPIRE",KEYS[1], ARGV[2])
-else
-    return 0
-end';
-        // ideally we would use evalSha to reduce bandwidth!
-        return (bool) $this->evalScript($script, array($key), array($value, (int) $ttlInSeconds));
+        if (self::$expireScriptSha1 === null) {
+            self::$expireScriptSha1 = sha1(self::EXPIRE_SCRIPT_CONTENT);
+        }
+
+        try {
+            return (bool) $this->redis->evalSha(self::$expireScriptSha1, array($key, $value, (int) $ttlInSeconds), 1);
+        } catch (\RedisException $e) {
+            if (strpos($e->getMessage(), 'NOSCRIPT') !== false) {
+                return (bool) $this->redis->eval(self::EXPIRE_SCRIPT_CONTENT, array($key, $value, (int) $ttlInSeconds), 1);
+            }
+            throw $e;
+        }
     }
 
     public function get($key)

--- a/tests/Integration/Queue/Backend/RedisTest.php
+++ b/tests/Integration/Queue/Backend/RedisTest.php
@@ -330,4 +330,65 @@ class RedisTest extends IntegrationTestCase
         $keys    = $backend->getKeysMatchingPattern('*fere*');
         $this->assertEquals(array(), $keys);
     }
+
+    public function test_deleteIfKeyHasValue_evalShaFallback()
+    {
+        if (!$this->hasDependencies()) {
+            $this->markTestSkipped('Requires redis');
+        }
+
+        $rawRedis = $this->redis->getConnection();
+        $rawRedis->script('flush');
+
+        $key1 = 'evalShaDelKey1';
+        $value1 = 'val1';
+
+        // Test EVAL fallback
+        $this->redis->setIfNotExists($key1, $value1, 60);
+        $this->assertNotEmpty($this->redis->get($key1), "Key $key1 should exist before deleteIfKeyHasValue (EVAL)");
+        $this->assertTrue($this->redis->deleteIfKeyHasValue($key1, $value1), "deleteIfKeyHasValue for $key1 should return true (EVAL)");
+        $this->assertFalse($this->redis->get($key1), "Key $key1 should be deleted after deleteIfKeyHasValue (EVAL)");
+
+        $key2 = 'evalShaDelKey2';
+        $value2 = 'val2';
+
+        // Test EVALSHA (script should be cached now)
+        $this->redis->setIfNotExists($key2, $value2, 60);
+        $this->assertNotEmpty($this->redis->get($key2), "Key $key2 should exist before deleteIfKeyHasValue (EVALSHA)");
+        $this->assertTrue($this->redis->deleteIfKeyHasValue($key2, $value2), "deleteIfKeyHasValue for $key2 should return true (EVALSHA)");
+        $this->assertFalse($this->redis->get($key2), "Key $key2 should be deleted after deleteIfKeyHasValue (EVALSHA)");
+    }
+
+    public function test_expireIfKeyHasValue_evalShaFallback()
+    {
+        if (!$this->hasDependencies()) {
+            $this->markTestSkipped('Requires redis');
+        }
+
+        $rawRedis = $this->redis->getConnection();
+        $rawRedis->script('flush');
+
+        $key1 = 'evalShaExpKey1';
+        $value1 = 'valExp1';
+        $ttlSeconds = 1;
+
+        // Test EVAL fallback
+        $this->redis->setIfNotExists($key1, $value1, 60); // Set with a longer initial TTL
+        $this->assertNotEmpty($this->redis->get($key1), "Key $key1 should exist before expireIfKeyHasValue (EVAL)");
+        $this->assertTrue($this->redis->expireIfKeyHasValue($key1, $value1, $ttlSeconds), "expireIfKeyHasValue for $key1 should return true (EVAL)");
+        $this->assertLessThanOrEqual($ttlSeconds * 1000, $this->redis->getTimeToLive($key1), "TTL for $key1 should be reduced (EVAL)");
+        sleep($ttlSeconds + 1); // Wait for key to expire
+        $this->assertFalse($this->redis->get($key1), "Key $key1 should be expired after wait (EVAL)");
+
+        $key2 = 'evalShaExpKey2';
+        $value2 = 'valExp2';
+
+        // Test EVALSHA (script should be cached now)
+        $this->redis->setIfNotExists($key2, $value2, 60); // Set with a longer initial TTL
+        $this->assertNotEmpty($this->redis->get($key2), "Key $key2 should exist before expireIfKeyHasValue (EVALSHA)");
+        $this->assertTrue($this->redis->expireIfKeyHasValue($key2, $value2, $ttlSeconds), "expireIfKeyHasValue for $key2 should return true (EVALSHA)");
+        $this->assertLessThanOrEqual($ttlSeconds * 1000, $this->redis->getTimeToLive($key2), "TTL for $key2 should be reduced (EVALSHA)");
+        sleep($ttlSeconds + 1); // Wait for key to expire
+        $this->assertFalse($this->redis->get($key2), "Key $key2 should be expired after wait (EVALSHA)");
+    }
 }


### PR DESCRIPTION
This commit introduces an optimization to the Redis queue backend by using EVALSHA for executing Lua scripts in the `deleteIfKeyHasValue` and `expireIfKeyHasValue` methods.

Changes include:
- Lua script content and their SHA1 hashes are now stored in static properties within the `Queue/Backend/Redis.php` class.
- The `deleteIfKeyHasValue` and `expireIfKeyHasValue` methods first attempt to execute scripts using `EVALSHA`.
- If a 'NOSCRIPT' error occurs (indicating the script is not in Redis's cache), the methods fall back to using `EVAL` to execute the script, which also caches it in Redis for subsequent calls.
- The generic `evalScript` method was removed, and its logic was incorporated directly into the relevant methods.

New unit tests were added to `tests/Integration/Queue/Backend/RedisTest.php`:
- These tests specifically verify the `EVALSHA` fallback mechanism by flushing the Redis script cache before execution.
- They ensure that the core functionality of deleting and expiring keys based on values remains correct with the new script execution strategy.

This optimization reduces network bandwidth between the application and Redis and leverages Redis's script caching capabilities for improved performance.