### PR TITLE
Stop Disabling Provider Plugin When QueuedTracking Is Enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-5.2.0 - 2025-11-24
+5.2.0 - 2025-11-25
 - No longer disable Provider plugin automatically. If performance issues occur, please disable it manually or install an ASN geolocation database (https://matomo.org/faq/how-to/setting-up-accurate-visitors-geolocation/).
 
 5.1.3 - 2025-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+5.2.0 - 2025-11-24
+- No longer disable Provider plugin automatically. If performance issues occur, please disable it manually or install an ASN geolocation database (https://matomo.org/faq/how-to/setting-up-accurate-visitors-geolocation/).
+
 5.1.3 - 2025-09-01
 - Add support for Sentinel password
 - Security hardening

--- a/Commands/Process.php
+++ b/Commands/Process.php
@@ -75,7 +75,6 @@ class Process extends ConsoleCommand
 
         Log::unsetInstance();
         $trackerEnvironment->getContainer()->get('Piwik\Access')->setSuperUserAccess(false);
-        $trackerEnvironment->getContainer()->get('Piwik\Plugin\Manager')->setTrackerPluginsNotToLoad(array('Provider'));
         Tracker::loadTrackerEnvironment();
 
         $backend      = Queue\Factory::makeBackend();

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "QueuedTracking",
-    "version": "5.1.3",
+    "version": "5.2.0",
     "description": "Scale your large traffic Matomo service by queuing tracking requests in Redis or MySQL for better performance and reliability when experiencing peaks.",
     "theme": false,
     "keywords": ["tracker", "tracking", "queue", "redis"],


### PR DESCRIPTION
## Description
Fixes https://github.com/matomo-org/plugin-QueuedTracking/issues/136

Historically, QueuedTracking disabled the Provider plugin because provider lookups were slow when executed during the tracking request. That context has changed.

The plugin was not enabled by default in core and had to be enabled. Provider plugin is no longer part of core and must be explicitly installed from the Marketplace. When a user installs and enables the plugin, it’s a strong signal that they want provider data.

QueuedTracking’s blanket disabling of Provider leads to unexpected missing data for users who clearly opted in.

Additionally, performance concerns are no longer a good reason to disable the plugin:

* With an ASN database configured, Provider lookups are fast (this is also how we run it on Cloud).
* Even without an ASN database, Provider lookups executed in the queue won’t be any slower than in normal, synchronous tracking. In fact, overall performance will still be better.

Given these points, there’s no longer a justification for QueuedTracking to disable Provider automatically. This PR removes that behavior so users get the data they explicitly enabled.


## Issue No
Fixes #136



## Checklist
- [✔/✖] Tested locally or on demo2/demo3?
- [✔/✖/NA] New test case added/updated?
- [✔/✖/NA] Are all newly added texts included via translation?
- [✔/✖/NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔/✖/NA] Version bumped?