### PR TITLE
Fix PHPUnit deprecation warnings in integration tests

### DIFF
--- a/tests/Integration/Queue/ProcessorTest.php
+++ b/tests/Integration/Queue/ProcessorTest.php
@@ -313,45 +313,29 @@ class ProcessorTest extends IntegrationTestCase
                      ->setConstructorArgs(array($this->queue, $this->lock))
                      ->getMock();
 
-        $mock->expects($this->at(0))
+        $expectedRequestSetCalls = [
+            [1, 5],
+            [],
+            [1, 2],
+            [1],
+            [3, 1],
+            [],
+        ];
+        $mock->expects($this->exactly(count($expectedRequestSetCalls)))
              ->method('processRequestSets')
-             ->with($this->anything(), $this->callback(function ($arg) {
-                 return 2 === count($arg) && 1 === $arg[0]->getNumberOfRequests() &&  5 === $arg[1]->getNumberOfRequests();
-             }))
-            ->will($this->returnCallback($forwardCallToProcessor));
+             ->willReturnCallback(function ($tracker, $queuedRequestSets) use (&$expectedRequestSetCalls, $forwardCallToProcessor) {
+                 $expectedCounts = array_shift($expectedRequestSetCalls);
+                 $actualCounts = array_map(function ($requestSet) {
+                     return $requestSet->getNumberOfRequests();
+                 }, $queuedRequestSets);
 
-        $mock->expects($this->at(1))
-             ->method('processRequestSets')
-             ->with($this->anything(), $this->equalTo(array()))
-            ->will($this->returnCallback($forwardCallToProcessor));
+                 $this->assertSame($expectedCounts, $actualCounts);
 
-        $mock->expects($this->at(2)) // one of them fails
-             ->method('processRequestSets')
-             ->with($this->anything(), $this->callback(function ($arg) {
-                 return 2 === count($arg) && 1 === $arg[0]->getNumberOfRequests() &&  2 === $arg[1]->getNumberOfRequests();
-             }))
-             ->will($this->returnCallback($forwardCallToProcessor));
-
-        $mock->expects($this->at(3)) // retry, this time it should work
-             ->method('processRequestSets')
-             ->with($this->anything(), $this->callback(function ($arg) {
-                 return 1 === count($arg) && 1 === $arg[0]->getNumberOfRequests();
-             }))
-            ->will($this->returnCallback($forwardCallToProcessor));
-
-        $mock->expects($this->at(4)) // both of them fails
-             ->method('processRequestSets')
-             ->with($this->anything(), $this->callback(function ($arg) {
-                 return 2 === count($arg) && 3 === $arg[0]->getNumberOfRequests() &&  1 === $arg[1]->getNumberOfRequests();
-             }))
-             ->will($this->returnCallback($forwardCallToProcessor));
-
-        $mock->expects($this->at(5))  // as both fail none should be retried
-             ->method('processRequestSets')
-             ->with($this->anything(), $this->equalTo(array()))
-             ->will($this->returnCallback($forwardCallToProcessor));
+                 return $forwardCallToProcessor($tracker, $queuedRequestSets);
+             });
 
         $mock->process($this->createTracker());
+        $this->assertSame([], $expectedRequestSetCalls);
     }
 
     public function test_process_shouldRestoreEnvironmentAfterTrackingRequests()


### PR DESCRIPTION
## Description

This PR removes PHPUnit deprecation warnings in affected integration tests to improve PHPUnit 10 compatibility.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
