### PR TITLE
Fix failing tests on 5.x-dev [no_release]

### DIFF
--- a/tests/UI/QueuedTrackingSettings_spec.js
+++ b/tests/UI/QueuedTrackingSettings_spec.js
@@ -37,8 +37,9 @@ describe("QueuedTrackingSettings", function () {
         await page.click('#queueEnabled + span');
         await page.type('input[name="redisPort"]', '1');
         await (await page.jQuery('.card-content:contains(\'QueuedTracking\') .pluginsSettingsSubmit')).click();
-        await page.type('.confirm-password-modal input[type=password]', superUserPassword);
-        await page.click('.confirm-password-modal .modal-close.btn');
+        await page.waitForSelector('.confirm-password-modal.open', { visible: true });
+        await page.type('.confirm-password-modal.open input[type=password]', superUserPassword);
+        await (await page.jQuery('.confirm-password-modal .confirm-password-btn:visible')).click();
         await page.waitForNetworkIdle();
         // hide all cards, except of QueueTracking
         await page.evaluate(function(){


### PR DESCRIPTION
## Description
Automated fix for failing tests on `5.x-dev`.

- Failing workflow: Plugin QueuedTracking Tests
- Failing job(s): UI
- CI run: https://github.com/matomo-org/plugin-QueuedTracking/actions/runs/27858161172

Generated by automated-test-fixes.

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->


## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?