### PR TITLE
Run plugin tests against MySQL 8.0 and MariaDB 10.6

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -39,6 +39,9 @@ jobs:
       matrix:
         php: [ '8.1', '8.5' ]
         target: ['minimum_required_matomo', 'maximum_supported_matomo']
+        database:
+          - { engine: 'Mysql', version: '8.0' }
+          - { engine: 'Mariadb', version: '10.6' }
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,6 +55,8 @@ jobs:
           plugin-name: 'QueuedTracking'
           php-version: ${{ matrix.php }}
           test-type: 'PluginTests'
+          mysql-engine: ${{ matrix.database.engine }}
+          mysql-version: ${{ matrix.database.version }}
           matomo-test-branch: ${{ matrix.target }}
           redis-service: true
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
@@ -69,6 +74,8 @@ jobs:
           plugin-name: 'QueuedTracking'
           matomo-test-branch: 'maximum_supported_matomo'
           test-type: 'UI'
+          mysql-engine: 'Mysql'
+          mysql-version: '8.0'
           php-version: '8.1'
           node-version: '16'
           redis-service: true

--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -60,7 +60,7 @@ jobs:
           matomo-test-branch: ${{ matrix.target }}
           redis-service: true
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
-          upload-artifacts: ${{ matrix.php == '8.1' && matrix.target == 'maximum_supported_matomo' }}
+          upload-artifacts: ${{ matrix.php == '8.1' && matrix.target == 'maximum_supported_matomo' && matrix.database.engine == 'Mysql' }}
   UI:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary

Updates the plugin test workflow to run against the new minimum supported database versions. It previously inherited the shared `github-action-tests` MySQL 5.7 default, which is below Matomo's new minimum (MySQL 8.0 / MariaDB 10.6).

**Core PR:** https://github.com/matomo-org/matomo/pull/24858

- **PluginTests** now runs a database matrix: **MySQL 8.0** and **MariaDB 10.6**.
- **UI** (and **JS**, where present) run on **MySQL 8.0**.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
